### PR TITLE
remove semicolon

### DIFF
--- a/termgraph.py
+++ b/termgraph.py
@@ -455,7 +455,7 @@ def calendar_heatmap( data, labels, args ):
             sys.stdout.write( T )
             if colornum:
                 sys.stdout.write( '\033[0m' )
-        sys.stdout.write( '\n' );
+        sys.stdout.write( '\n' )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello.

`sys.stdout.write( '\n' );`

I think the semicolon is unnecessary.
So, I removed it.

`sys.stdout.write( '\n' )`

Please review.
Thanks.