### PR TITLE
Crossplatform fix: strip STDIN string from single and double quotes

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -372,7 +372,7 @@ def read_data( args ):
 
     f = sys.stdin if stdin else open( filename, "r" )
     for line in f:
-        line = line.strip()
+        line = line.replace("\"", "").replace("\'", "").strip()
         if line:
             if not line.startswith( '#' ):
                 if line.find( DELIM ) > 0:


### PR DESCRIPTION
This fix is aimed to circumvent Windows10 CMD `echo` behaviour. Hope it doesnt break Linux compatibility ^_^