### PR TITLE
Changing normalize() method

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -121,10 +121,13 @@ def normalize( data, width ):
         # is less than the width we allow.
         return off_data
 
-    norm_factor = width / float( max_dat - min_dat )
+    # max_dat / width is the value for a single tick. norm_factor is the inverse of this value
+    # If you divide a number to the value of single tick, you will find how many ticks it does
+    # contain basically.
+    norm_factor = width / float(max_dat)
     normal_dat = []
     for dat in off_data:
-        normal_dat.append( [ ( _v - min_dat ) * norm_factor for _v in dat ] )
+        normal_dat.append( [ _v * norm_factor for _v in dat ] )
     return normal_dat
 
 # Prepares the horizontal graph.


### PR DESCRIPTION
normalize() method had two problems and this commit is aiming to solve
them

- Zero division error. If values are bigger than width and they are all
  equal, program terminates with a zero division error because max and
  minimum values are equal.
- Minimum value always plotted as zero in normalized graphs.

  For example; in a case when width = 50, minimum value = 199 and
  maximum value = 200, termgraph will plot the min value as zero and the
  max value as 50. Normally, the min value should be just a little shorter
  than the max value.