### PR TITLE
Configure setup.py to only install in python >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     description='a python command-line tool which draws basic graphs in the terminal',
     platforms='any',
     keywords='python CLI tool drawing graphs shell terminal',
+    python_requires='>=3.6',
     install_requires=['colorama'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Currently termgraph can only run under python 3.6 (see #28).

To avoid surprising users at runtime with a `SyntaxError` message, I think it makes sense to prevent installation altogether in python < 3.6. These changes enforce a python >=3.6 at the setup.py level.

@mkaz Let me know if you're interested in making the package backwards compatible. I'd be happy to help!
