### PR TITLE
Treat zero data points the same as missing data points.

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -569,7 +569,7 @@ def calendar_heatmap(data, labels, args):
             day_ = start_dt + timedelta(days=day + week*7)
             day_str = day_.strftime("%Y-%m-%d")
 
-            if day_str in dt_dict:
+            if day_str in dt_dict and dt_dict[day_str] != 0.0:
                 if dt_dict[day_str] > max_val * 0.75:
                     tick = tick_4
                 elif dt_dict[day_str] > max_val * 0.50:


### PR DESCRIPTION
Sometimes the data set contains zero-valued data points. Since they are exactly
zero, they should IMO be treated the same as when a data point is missing.
However, they are currently displayed as non-zero values from the bottom
quartile.

This PR changes this behaviour to treat them the same as missing data points
(printing a space).