### PR TITLE
Fix bug of different-scale option about indentation

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -388,7 +388,7 @@ def chart(colors, data, args, labels):
 
                 print()
                 value_list.clear(), zipped_list.clear(), vertical_list.clear()
-                return
+            return
 
     # One category/Multiple series graph with same scale
     # All-together normalization


### PR DESCRIPTION
This PR purposed to fix bug of `--different-scale` option caused by wrong indentation.

Used data: `data/ex8.dat`
```
# Example Data Set 8 with Categories of different scale
@ People,Income
2007,100,500000
2008,450.23,760000
2009,255,1000000
2010,340,800000
2011,160,600400
2012,200,950000
2014,488,700000
```

When I plotted 2 categories data (that is above one) having different-scale, the output is as follows:
<img width="523" alt="スクリーンショット 2019-11-18 16 08 12" src="https://user-images.githubusercontent.com/15909860/69031532-a530f580-0a1d-11ea-9896-1563cb36763c.png">

However, I think the ideal output is to have two normalized plots by category.
So, when I was reading source code of termgraph, I found a wrong indentation in block treating `different-scale`.

The output after fixing indentation is as follows:
<img width="640" alt="スクリーンショット 2019-11-18 16 15 47" src="https://user-images.githubusercontent.com/15909860/69031971-b3cbdc80-0a1e-11ea-93db-af8b414c339f.png">


 
