### PR TITLE
Rename arg to label-before

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name='termgraph',
     packages=['termgraph'],
     entry_points={'console_scripts': ['termgraph=termgraph.termgraph:main']},
-    version='0.2.0',
+    version='0.2.2',
     author="mkaz",
     author_email="marcus@mkaz.com",
     url='https://github.com/mkaz/termgraph',

--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -13,7 +13,7 @@ from itertools import zip_longest
 from colorama import init
 
 
-VERSION = '0.2.0'
+VERSION = '0.2.2'
 
 init()
 
@@ -118,7 +118,7 @@ def init_args():
         help='Verbose output, helpful for debugging'
     )
     parser.add_argument(
-        '--reverse',
+        '--label-before',
         action='store_true',
         help='Display the values before the bars'
     )
@@ -217,7 +217,7 @@ def horiz_rows(labels, data, normal_dat, args, colors, doprint = True):
             # Hide the labels.
             label = ''
         else:
-            if args['reverse']:
+            if args['label_before']:
                 fmt = "{:<{x}}"
             else:
                 fmt = "{:<{x}}: "
@@ -233,7 +233,7 @@ def horiz_rows(labels, data, normal_dat, args, colors, doprint = True):
             if j > 0:
                 len_label = len(label)
                 label = ' ' * len_label
-            if args['reverse']:
+            if args['label_before']:
                 fmt = '{}{}'
             else:
                 fmt = ' {}{}'
@@ -417,7 +417,7 @@ def chart(colors, data, args, labels):
     if not args['stacked']:
         normal_dat = normalize(data, args['width'])
         sys.stdout.write('\033[0m') # no color
-        for row in horiz_rows(labels, data, normal_dat, args, colors, not args['reverse']):
+        for row in horiz_rows(labels, data, normal_dat, args, colors, not args['label_before']):
             if not args['vertical']:
                 print_row(*row)
             else:


### PR DESCRIPTION

This renames the `reverse` arg to `label-before`
Props to @wgxo for the contribution.