### PR TITLE
Fix bug in find_min and find_max functions

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -162,11 +162,11 @@ def main():
 
 def find_min(list_):
     """Return the minimum value in sublist of list."""
-    return min([sublist[-1] for sublist in list_])
+    return min([min(sublist) for sublist in list_])
 
 def find_max(list_):
     """Return the maximum value in sublist of list."""
-    return max([sublist[-1] for sublist in list_])
+    return max([max(sublist) for sublist in list_])
 
 def find_max_label_length(labels):
     """Return the maximum length for the labels."""


### PR DESCRIPTION
First: thanks @mkaz for this nice tool!

With this I would like to fix something that looks like a bug, unless I'm missing something.

When using the '--width' option on a dataset with multiple categories, I was not getting the expected (maximum) width because the find_max function was only looking at the last category, while in my case the highest values were in the first category. Same for find_min().