### PR TITLE
docs: fix simple typo, pritn -> print

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -482,7 +482,7 @@ def chart(colors: List, data: List, args: Dict, labels: List) -> None:
                     else:
                         print_row(*row)
 
-                # The above gathers data for vertical and does not pritn
+                # The above gathers data for vertical and does not print
                 # the final print happens at once here
                 if args["vertical"]:
                     print_vertical(vertic, labels, colors[i], args)


### PR DESCRIPTION
There is a small typo in termgraph/termgraph.py.

Should read `print` rather than `pritn`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md