### PR TITLE
Handle BrokenPipeError

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -125,10 +125,13 @@ def main():
         sys.exit()
 
     _, labels, data, colors = read_data(args)
-    if args["calendar"]:
-        calendar_heatmap(data, labels, args)
-    else:
-        chart(colors, data, args, labels)
+    try:
+        if args["calendar"]:
+            calendar_heatmap(data, labels, args)
+        else:
+            chart(colors, data, args, labels)
+    except BrokenPipeError:
+        pass
 
 
 def find_min(data: List):


### PR DESCRIPTION
Closes https://github.com/mkaz/termgraph/issues/80

```
$ cat <<EOF | termgraph | head -n 5
2021-05-30      15
2021-05-29      20
2021-05-28      21
2021-05-27      19
2021-05-26      19
2021-05-25      18
2021-05-24      18
2021-05-23      19
2021-05-22      19
EOF

2021-05-30: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 15.00
2021-05-29: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 20.00
2021-05-28: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 21.00
2021-05-27: ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19.00
Exception ignored in: <colorama.ansitowin32.StreamWrapper object at 0x104ff40d0>
BrokenPipeError: [Errno 32] Broken pipe
```

There is an issue open for the remaining colorama error: https://github.com/tartley/colorama/issues/302