### PR TITLE
Fixing AttributeError: type object 'Colors' has no attribute 'black'

### DIFF
--- a/termgraph/module.py
+++ b/termgraph/module.py
@@ -324,7 +324,7 @@ class HorizontalChart(Chart):
         sys.stdout.write("\033[0m")  # no color
 
         if value == 0.0:
-            sys.stdout.write(f"\033[{Colors.black}m")  # dark gray
+            sys.stdout.write(f"\033[{Colors.Black}m")  # dark gray
 
         if doprint:
             print(label, tail, " ", end="")


### PR DESCRIPTION
Fixing the below exception when the value `0.0` is plotted

```
  File "/home/cmuck/Documents/Isas-script/venv/lib/python3.8/site-packages/termgraph/module.py", line 327, in print_row
    sys.stdout.write(f"\033[{Colors.black}m")  # dark gray
AttributeError: type object 'Colors' has no attribute 'black' 
```