### PR TITLE
Percentage feature

### DIFF
--- a/termgraph/module.py
+++ b/termgraph/module.py
@@ -184,6 +184,7 @@ class Args(object):
         "delim": "",
         "verbose": False,
         "label_before": False,
+        "percentage": False
     }
 
     def __init__(self, **kwargs: Dict):

--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -103,6 +103,10 @@ def init_args() -> Dict:
     parser.add_argument(
         "--version", action="store_true", help="Display version and exit"
     )
+    parser.add_argument(
+        "--percentage", action="store_true", help="Display the number in percentage, as {:.0%}"
+    )
+
     if len(sys.argv) == 1:
         if sys.stdin.isatty():
             parser.print_usage()
@@ -185,7 +189,7 @@ def find_max_label_length(labels: List) -> int:
     return max([len(label) for label in labels])
 
 
-def cvt_to_readable(num):
+def cvt_to_readable(num, percentage=False):
     """Return the number in a human readable format
 
     Eg:
@@ -193,6 +197,9 @@ def cvt_to_readable(num):
     12550 -> 12.55K
     19561100 -> 19.561M
     """
+    if percentage:
+      return (num * 100, "%")
+
 
     if num != 0:
         neg = num < 0
@@ -317,7 +324,7 @@ def horiz_rows(
             if args["no_values"]:
                 tail = args["suffix"]
             else:
-                val, deg = cvt_to_readable(values[j])
+                val, deg = cvt_to_readable(values[j], percentage=args["percentage"])
                 tail = fmt.format(args["format"].format(val), deg, args["suffix"])
 
             if colors:

--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -104,7 +104,7 @@ def init_args() -> Dict:
         "--version", action="store_true", help="Display version and exit"
     )
     parser.add_argument(
-        "--percentage", action="store_true", help="Display the number in percentage, as {:.0%}"
+        "--percentage", action="store_true", help="Display the number in percentage, ignoring units and respecting the format flag"
     )
 
     if len(sys.argv) == 1:


### PR DESCRIPTION
Adds a percentage flag that can be useful to display percentage data. Sample data bellow:

```csv
"2019-12-31",1.0013737317
"2020-12-31",1.5375951236
"2021-12-31",1.1339880667
"2022-12-31",0.9593346671
"2023-02-14",1.0422348887
```

And print it in the following format:
```sh
termgraph --percentage bla.csv
```
```
"2019-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 100.14%
"2020-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 153.76%
"2021-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 113.40%
"2022-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 95.93%
"2023-02-14": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 104.22%
```

Instead of:
```sh
termgraph bla.csv
```
```
"2019-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1.00 
"2020-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1.54 
"2021-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1.13 
"2022-12-31": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 959.34T
"2023-02-14": ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1.04 
```
