### PR TITLE
(fix) issue with numbers between -1 and 1; resolves issue 105

### DIFF
--- a/termgraph/termgraph.py
+++ b/termgraph/termgraph.py
@@ -194,7 +194,7 @@ def cvt_to_readable(num):
     19561100 -> 19.561M
     """
 
-    if num != 0:
+    if num >= 1 or num <= -1:
         neg = num < 0
         num = abs(num)
 
@@ -207,7 +207,7 @@ def cvt_to_readable(num):
         degree = UNITS[index]
 
     else:
-        newNum = 0
+        newNum = num
         degree = UNITS[0]
 
     return (newNum, degree)


### PR DESCRIPTION
When a number is within the range of -1 and 1, the program erroneously applies the labeling process by multiplying it by 100 and subsequently appending the unit designation "T" to the resulting value.