### PR TITLE
Detect and allow for disorderly labels

### DIFF
--- a/tests/test_termgraph.py
+++ b/tests/test_termgraph.py
@@ -1,3 +1,4 @@
+import tempfile
 from unittest.mock import patch
 from io import StringIO
 from termgraph import termgraph as tg
@@ -400,6 +401,73 @@ def test_read_data_returns_correct_results():
         [30.0, 20.0],
     ]
     assert colors == []
+
+
+def test_concatenate_neighboring_labels():
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        args = {
+            "filename": tmp.name,
+            "title": None,
+            "width": 50,
+            "format": "{:<5.2f}",
+            "suffix": "",
+            "no_labels": False,
+            "color": None,
+            "vertical": False,
+            "stacked": False,
+            "different_scale": False,
+            "calendar": False,
+            "start_dt": None,
+            "custom_tick": "",
+            "delim": "",
+            "verbose": False,
+            "version": False,
+        }
+        tmp.write(
+            """
+label one 1 2 3
+label two 5 6 7
+label three 9 10 11
+        """
+        )
+        tmp.seek(0)
+        categories, labels, data, colors = tg.read_data(args)
+        assert labels == ["label one", "label two", "label three"]
+        assert data == [[1.0, 2.0, 3.0], [5.0, 6.0, 7.0], [9.0, 10.0, 11.0]]
+
+
+def test_labels_at_end_of_row():
+    """Check that we can identify labels that come after the data"""
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        args = {
+            "filename": tmp.name,
+            "title": None,
+            "width": 50,
+            "format": "{:<5.2f}",
+            "suffix": "",
+            "no_labels": False,
+            "color": None,
+            "vertical": False,
+            "stacked": False,
+            "different_scale": False,
+            "calendar": False,
+            "start_dt": None,
+            "custom_tick": "",
+            "delim": "",
+            "verbose": False,
+            "version": False,
+        }
+        tmp.write(
+            """
+1 2 3 A
+5 6 7 B
+9 10 11 C
+        """
+        )
+        tmp.seek(0)
+        categories, labels, data, colors = tg.read_data(args)
+        assert labels == ["A", "B", "C"]
+        assert data == [[1.0, 2.0, 3.0], [5.0, 6.0, 7.0], [9.0, 10.0, 11.0]]
 
 
 def test_read_data_with_title_prints_title():


### PR DESCRIPTION
# Work with `sort | uniq -c`

With `sort | uniq -c`, you get a histogram with labels _after_ the data. These changes allow you to work with that kind of output.

So, given output like this:

```bash
% ./replay -q test_data/DewaltShuttle1.rep | ggrep -oE "^[A-Za-z]+"
Select
UnhandledCommand
Hotkey
Hotkey
Hotkey
TargetedOrderModern
Hotkey
TargetedOrderModern
Hotkey
Select
RightClick
RightClick
RightClick
SelectRemove
...
```

... and a `sort | uniq -c` histogram like this:

```bash
% ./replay -q test_data/DewaltShuttle1.rep | ggrep -oE "^[A-Za-z]+" | sort | uniq -c
 138 Build
   5 CancelTrain
   1 Chat
  86 HoldPosition
4379 Hotkey
   1 MergeArchon
  11 ReturnCargo
3054 RightClick
1435 Select
 142 SelectAdd
  43 SelectRemove
   2 Stop
 430 TargetedOrderModern
  10 TrainFighter
 677 UnhandledCommand
  23 UseAbility
```

We can now use `termgraph` to visualize the counted occurrences of unique words.

```bash
% ./replay -q test_data/DewaltShuttle1.rep | ggrep -oE "^[A-Za-z]+" | sort | uniq -c | sort | termgraph

Chat               : ▏ 1.00
MergeArchon        : ▏ 1.00
Stop               : ▏ 2.00
CancelTrain        : ▏ 5.00
TrainFighter       : ▏ 10.00
ReturnCargo        : ▏ 11.00
UseAbility         : ▏ 23.00
SelectRemove       : ▏ 43.00
HoldPosition       : ▏ 86.00
Build              : ▇ 138.00
SelectAdd          : ▇ 142.00
TargetedOrderModern: ▇▇▇▇ 430.00
UnhandledCommand   : ▇▇▇▇▇▇▇ 677.00
Select             : ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1.44 K
RightClick         : ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 3.05 K
Hotkey             : ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4.38 K
```

# Changes

- Labels can come after the data like in `sort | unique -c`
- Labels can be DELIM-separated, and concatenated via DELIM